### PR TITLE
fix: prevent dict mutation during cache cleanup

### DIFF
--- a/cache/local_cache.py
+++ b/cache/local_cache.py
@@ -105,9 +105,15 @@ class ExpiringLocalCache(AbstractCache):
         根据过期时间清理缓存
         :return:
         """
-        for key, (value, expire_time) in self._cache_container.items():
-            if expire_time < time.time():
-                del self._cache_container[key]
+        # dict在迭代的同时修改会抛出RuntimeError: dictionary changed size during iteration
+        # 因此先收集所有需要删除的key，最后再统一删除
+        expired_keys = [
+            key
+            for key, (_, expire_time) in self._cache_container.items()
+            if expire_time < time.time()
+        ]
+        for key in expired_keys:
+            del self._cache_container[key]
 
     async def _start_clear_cron(self):
         """

--- a/test/test_expiring_local_cache.py
+++ b/test/test_expiring_local_cache.py
@@ -42,6 +42,16 @@ class TestExpiringLocalCache(unittest.TestCase):
         time.sleep(12)
         self.assertIsNone(self.cache.get('key'))
 
+    def test_clear_method_removes_expired_keys(self):
+        """确保_clear方法在删除过期键时不会触发迭代错误"""
+        self.cache.set("key1", "value1", 1)
+        self.cache.set("key2", "value2", 10)
+        time.sleep(2)
+        # 直接调用内部清理方法，之前的实现会在迭代删除时抛出异常
+        self.cache._clear()
+        self.assertIsNone(self.cache.get("key1"))
+        self.assertEqual(self.cache.get("key2"), "value2")
+
     def tearDown(self):
         del self.cache
 


### PR DESCRIPTION
## Summary
- avoid RuntimeError when cleaning expired items in `ExpiringLocalCache`
- add regression test for cache cleanup

## Testing
- `pytest test/test_expiring_local_cache.py`
- `pytest` *(fails: No module named 'PIL')*

------
https://chatgpt.com/codex/tasks/task_e_689addfa089083239ce91be23d98886c